### PR TITLE
Fixed: Sample page consnet label target

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             </select>
             <label for="address">Your full address:</label>
             <textarea name="address" id="address" cols="40" rows="3" placeholder="PO box is not allowed"></textarea>
-            <input type="checkbox" name="consent" value="test"/>
+            <input type="checkbox" name="consent" id="consent" value="test"/>
             <label for="consent">I agree with all possible terms and conditions</label>
             <button type="submit">Subscribe</button>
             <button type="reset">Reset</button>


### PR DESCRIPTION
`label` was not responding to clicks/taps