### PR TITLE
Andriod th boldness fix

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -28,11 +28,11 @@ th {
 
 td,
 th {
-  border-bottom: 1px solid $gray;
+  border-bottom: (.06 * $em) solid $gray;
   padding: .825 * $em $em;
 }
 
 thead th {
-  border-bottom-width: 2px;
+  border-bottom-width: .12 * $em;
   padding-bottom: .35 * $em;
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -23,7 +23,7 @@
 @import 'defs';
 
 th {
-  font-weight: 500;
+  font-weight: 600;
 }
 
 td,

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -32,3 +32,7 @@ th {
   padding: .825 * $em $em;
 }
 
+thead th {
+  border-bottom-width: 2px;
+  padding-bottom: .35 * $em;
+}


### PR DESCRIPTION
Since the Android's fallback font Arial does not have a sensible font-weight: 500 and the Helvetica Neue looked too bold with 600, there's now added emphasis when using <thead>.

This is because the <th> can also be somewhere else, e.g. the first element of the row:
```html
<table>
  <tbody>
    <tr>
      <th>Name</th>
      <td>Cat</td>
      <td>Human</td>
    </tr>
    <tr>
      <th>Legs</th>
      <td>4</td>
      <td>2</td>
    </tr>
  </tbody>
</table>
```

In that case it makes no sense to always have the <th> tag have different margins and borders, just when it is inside the <thead> tag.

Quick screenshot:
![screen shot 2015-04-11 at 01 01 19](https://cloud.githubusercontent.com/assets/2676795/7098228/7893faf6-dfe6-11e4-9d60-6725f8027a60.png)

