### PR TITLE
Fixed: W3C validator error

### DIFF
--- a/scss/_responsive.scss
+++ b/scss/_responsive.scss
@@ -44,16 +44,17 @@
     min-width: 0;
   }
   
-  // The following lines fixes fieldset overflow bug in Firefox browser.
-  // For further info, see:
-  // http://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685
-  @-moz-document url-prefix() {
-    fieldset {
-      display: table-cell;
-    }
-  }
-  
   section {
     width: auto;
+  }
+  
+  fieldset,
+  x:-moz-any-link {
+    // The following lines fixes fieldset overflow bug in Firefox browser.
+    // For further info, see:
+    // http://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685
+    // Changed the original `@-moz-document url-prefix` code to simpler
+    // `-moz-any-link` hack so W3C CSS validator will pass it.
+    display: table-cell;
   }
 }


### PR DESCRIPTION
Seems that there are browser hacks that W3C validator treats as warnings instead of errors.

Screenshot of the compiled css at W3C validator (with default configuration):

![screen shot 2015-06-04 at 23 05 09](https://cloud.githubusercontent.com/assets/2676795/7993344/2faaacf6-0b0e-11e5-9fd2-20aac527528d.png)

Result: The firefox hack now shows up as a warning.

Fixes #32 