### PR TITLE
Update readme with gem installs for scss_lint and compass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ $ grunt dev
 Now you can make changes to `.scss` files and refresh the page in the browser.
 CSS will be recompiled automatically on every change you make.
 
+If you have problems running the Grunt build you may need to install
+[scss-lint](https://github.com/brigade/scss-lint) and [compass](http://compass-style.org/):
+
+```
+gem update --system && gem install scss_lint compass
+```
+
 ## Got questions?
 
 If you have questions or general suggestions, don't hesitate to submit


### PR DESCRIPTION
Hi

To get Grunt running I had to install scss-lint and compass, I've added it to the README in case you think it's a worthwhile addition.

Many thanks
Ben.