### PR TITLE
Removed explicit specification of the stylesheet type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and use together with your HTML by adding:
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="tacit.min.css"/>
+    <link rel="stylesheet" href="tacit.min.css"/>
   </head>
 </html>
 ```

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="keywords" content="css, html5, css framework"/>
     <meta name="description" content="CSS Framework for Dummies"/>
-    <link rel="stylesheet" type="text/css" href="tacit.min.css"/>
+    <link rel="stylesheet" href="tacit.min.css"/>
     <title>tacit</title>
     <link rel="shortcut icon" type="image/gif" href="logo.gif"/>
   </head>
@@ -29,8 +29,7 @@
         <pre>&lt;!DOCTYPE html&gt;
 &lt;html&gt;
   &lt;head&gt;
-    &lt;link rel="stylesheet" type="text/css"
-      href="//yegor256.github.io/tacit/tacit.min.css"/&gt;
+    &lt;link rel="stylesheet" href="//yegor256.github.io/tacit/tacit.min.css"/&gt;
   &lt;/head&gt;
 &lt;/html&gt;</pre>
         <p>


### PR DESCRIPTION
According to the HTML5 specification, section 4.8.4.11:
"The default type for resources given by the `stylesheet` keyword is `text/css`."