### PR TITLE
Add img style

### DIFF
--- a/scss/_media.scss
+++ b/scss/_media.scss
@@ -20,12 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-@import 'defs';
-@import 'tables';
-@import 'forms';
-@import 'pre';
-@import 'headings';
-@import 'typography';
-@import 'grid';
-@import 'responsive';
-@import 'media';
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
Our team uses tacit in [this site](http://nodejs.jp/) with the addition of `img { max-width: 100%; }`.
It has a good effect to big images in small screens.