### PR TITLE
Remove ruby deps in sass building and linting

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -3,7 +3,6 @@ assets:
   npmrc: zerocracy/home#assets/npmrc
 install: |
   sudo gem install --no-ri pdd
-  sudo gem install --no-ri scss-lint
   npm install --no-color
 architect:
   - yegor256

--- a/.sasslintrc
+++ b/.sasslintrc
@@ -1,0 +1,10 @@
+files:
+  include: scss/*.scss
+rules:
+  nesting-depth: 0
+  no-qualifying-elements: 0
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+  force-attribute-nesting: 0
+  no-vendor-prefixes: 0
+  quotes: 0

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,6 +1,0 @@
----
-linters:
-  QualifyingElement:
-    enabled: false
-  NestingDepth:
-    enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: node_js
 git:
   depth: 10
 node_js:
-  - "0.12"
+  - 4
 addons:
   apt:
     packages:
       - ruby
 before_install:
-  - gem install --no-ri scss-lint
+  - gem install --no-ri sass
 install:
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,5 @@ git:
   depth: 10
 node_js:
   - 4
-addons:
-  apt:
-    packages:
-      - ruby
-before_install:
-  - gem install --no-ri sass
 install:
   - npm install
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,3 @@ $ npm run dev
 
 Now you can make changes to `.scss` files and refresh the page in the browser.
 CSS will be recompiled automatically on every change you make.
-
-If you have problems running the Grunt build you may need to install
-[scss-lint](https://github.com/brigade/scss-lint):
-
-```
-gem update --system && gem install scss_lint
-```
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,14 +61,10 @@ module.exports = function (grunt) {
           tasks: ['sass:dev']
         }
       },
-      scsslint: {
+      sasslint: {
         allFiles: [
-          'scss/*.scss',
-        ],
-        options: {
-          config: '.scss-lint.yml',
-          colorizeOutput: true
-        },
+          'scss/*.scss'
+        ]
       },
       shell: {
         target: {
@@ -82,10 +78,9 @@ module.exports = function (grunt) {
   );
   require('load-grunt-tasks') (grunt, { scope: 'devDependencies' });
   grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-scss-lint');
   grunt.loadNpmTasks('grunt-shell');
-  grunt.registerTask('default', ['scsslint', 'sass:dist', 'shell']);
-  grunt.registerTask('rultor', ['scsslint', 'sass:dist', 'sass:uncompressed', 'shell']);
-  grunt.registerTask('dev', ['scsslint', 'sass:dev', 'watch']);
+  grunt.registerTask('default', ['sasslint', 'sass:dist', 'shell']);
+  grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'shell']);
+  grunt.registerTask('dev', ['sasslint', 'sass:dev', 'watch']);
 }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,8 @@ module.exports = function (grunt) {
       sass: {
         dev: {
           options: {
-            style: 'compressed'
+            sourceMap: true,
+            outputStyle: 'compressed'
           },
           files: {
             'tacit.min.css': 'scss/main.scss'
@@ -39,7 +40,8 @@ module.exports = function (grunt) {
         },
         dist: {
           options: {
-            style: 'compressed'
+            sourceMap: true,
+            outputStyle: 'compressed'
           },
           files: {
             'dist/<%= pkg.name %>-<%= pkg.version %>.min.css': 'scss/main.scss'
@@ -47,8 +49,8 @@ module.exports = function (grunt) {
         },
         uncompressed: {
           options: {
-            sourcemap: 'none',
-            style: 'expanded'
+            sourceMap: false,
+            outputStyle: 'expanded'
           },
           files: {
             'dist/<%= pkg.name %>-<%= pkg.version %>.css': 'scss/main.scss'
@@ -77,7 +79,6 @@ module.exports = function (grunt) {
     }
   );
   require('load-grunt-tasks') (grunt, { scope: 'devDependencies' });
-  grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-shell');
   grunt.registerTask('default', ['sasslint', 'sass:dist', 'shell']);
   grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'shell']);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,7 @@ branches:
   except:
     - gh-pages
 os: Windows Server 2012
-install:
-  - cmd: SET PATH=C:\Ruby200\bin;%PATH%
-  - cmd: ruby --version
 build_script:
-  - gem install --no-ri scss-lint
   - npm install
 test_script:
   - npm test
-cache:
-  - C:\Ruby200\bin -> Gemfile
-  - C:\Ruby200\lib\ruby\gems\2.0.0 -> Gemfile

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "homepage": "https://github.com/yegor256/tacit",
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-sass": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
+    "grunt-sass": "^2.0.0",
     "grunt-sass-lint": "^0.2.4",
     "grunt-shell": "1.1.2",
     "load-grunt-tasks": "3.4.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-sass": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-scss-lint": "0.3.8",
+    "grunt-sass-lint": "^0.2.4",
     "grunt-shell": "1.1.2",
     "load-grunt-tasks": "3.4.0"
   }


### PR DESCRIPTION
This PR tries to replace ruby dependencies from scss building and linting. (closes #72)

Here is summary of the changes:
- Replaced grunt-contrib-sass (depends on sass gem) with grunt-sass (depends on node-sass)
- Replaced grunt-scss-lint (depends on scss-lint gem) with grunt-sass-lint (depends sass-lint npm module)
  - I created .scsslintrc which passes the current scss code without any error with minimal rule settings.
- Updated node.js version on travis to 4 because some of grunt-sass-lint deps only supports node.js >= 4 and unable to lint with node.js 0.12.
- I deleted lines about gem installation from CI setting files and contributing guides.