### PR TITLE
Modify grunt shell task to check copyright years

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,17 +69,13 @@ module.exports = function (grunt) {
         ]
       },
       shell: {
-        target: {
-          command: 'grep -q -r 2015-' + new Date().getFullYear()
-            + ' --include "*.scss"'
-            + ' --include "*.js"'
-            + ' .'
+        checkYear: {
+	  command: 'git ls-files LICENSE "*.scss" "*.html" "*.js" | xargs -L1 grep -q 2015-' + new Date().getFullYear()
         }
       }
     }
   );
   require('load-grunt-tasks') (grunt, { scope: 'devDependencies' });
-  grunt.loadNpmTasks('grunt-shell');
   grunt.registerTask('default', ['sasslint', 'sass:dist', 'shell']);
   grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'shell']);
   grunt.registerTask('dev', ['sasslint', 'sass:dev', 'watch']);

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
         <nav>
           <ul>
             <li>
-              <small>Made by <a href="http://www.yegor256.com">Yegor Bugayenko</a>, 2015 - 2017</small>
+              <small>Made by <a href="http://www.yegor256.com">Yegor Bugayenko</a>, 2015-2017</small>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
This PR modifies `grunt shell` task to check if all the files which include the copyright line have the correct year in it. I included `*.js`, `*.scss`, `*.html` and LICENSE as target files.

closes #76 