### PR TITLE
 Fixed spacing between form elements

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -65,6 +65,10 @@ label {
   + * {
     page-break-before: always;
   }
+
+  > input{
+    margin-bottom: 0;
+  }
 }
 
 input[type="submit"],
@@ -89,7 +93,6 @@ button {
     color: darken($gray, 10);
     cursor: not-allowed;
   }
-
 }
 
 input[type="submit"],
@@ -101,26 +104,9 @@ button[type="submit"] {
     background: darken($blue, 15);
     color: darken($white, 25);
   }
-
 }
 
-input[type="text"],
-input[type="password"],
-input[type="email"],
-input[type="url"],
-input[type="phone"],
-input[type="tel"],
-input[type="number"],
-input[type="datetime"],
-input[type="date"],
-input[type="month"],
-input[type="week"],
-input[type="color"],
-input[type="time"],
-input[type="search"],
-input[type="range"],
-input[type="file"],
-input[type="datetime-local"],
+input,
 select,
 textarea {
   border: 1px solid $gray;
@@ -142,7 +128,5 @@ input[type="radio"] {
 }
 
 select[multiple] {
-  margin-bottom: 0;
   min-width: 15 * $em;
 }
-

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -93,6 +93,7 @@ button {
     color: darken($gray, 10);
     cursor: not-allowed;
   }
+
 }
 
 input[type="submit"],
@@ -107,10 +108,30 @@ button[type="submit"] {
 }
 
 input,
+select {
+  margin-bottom: $em;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="url"],
+input[type="phone"],
+input[type="tel"],
+input[type="number"],
+input[type="datetime"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="color"],
+input[type="time"],
+input[type="search"],
+input[type="range"],
+input[type="file"],
+input[type="datetime-local"],
 select,
 textarea {
   border: 1px solid $gray;
-  margin-bottom: $em;
   padding: .3 * $em .35 * $em;
 }
 

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -108,7 +108,8 @@ button[type="submit"] {
 }
 
 input,
-select {
+select,
+textarea{
   margin-bottom: $em;
 }
 


### PR DESCRIPTION
- Removed crazy specificity for (almost) all input types 
- Removed double margin-bottom:

As stated in #106 labels can be used as a surrounding element:

```
<label>
  Another field, this time inside label:
  <input name="email" type="text" id="email" size="25" placeholder="must be unique"/>
</label>
```

This created a double margin bottom if used in 'normal' inputs:

![chrome_2017-10-25_16-07-20](https://user-images.githubusercontent.com/5692603/32008932-7e35d75e-b9a5-11e7-8137-b25735055b83.png)

- Also fixed inconsistent select margin