### PR TITLE
#blockquote: no margin for P inside BLOCKQUOTE

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -152,6 +152,10 @@ blockquote {
     font-size: .75 * $em;
     margin: 0;
   }
+
+  p {
+    margin-bottom: 0;
+  }
 }
 
 img {


### PR DESCRIPTION
Would be great to merge this too. We don't need that margin if the `P` is inside the `BLOCKQUOTE`.