### PR TITLE
#maxwidth: maxwidth to all

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -39,7 +39,6 @@ button {
   @extend %sans-serif;
   border-radius: .2 * $em;
   display: inline-block;
-  max-width: 100%;
   padding: .55 * $em;
 
   + label,

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -26,6 +26,7 @@
   border-spacing: 0;
   box-sizing: border-box;
   margin: 0;
+  max-width: 100%;
   outline: 0;
   padding: 0;
   text-align: left;
@@ -66,7 +67,6 @@ address {
 section {
   margin-left: auto;
   margin-right: auto;
-  max-width: 100%;
   width: 50 * $em;
 }
 
@@ -161,7 +161,6 @@ blockquote {
 img {
   height: auto;
   margin: 0 auto;
-  max-width: 100%;
 }
 
 figure {

--- a/scss/_responsive.scss
+++ b/scss/_responsive.scss
@@ -33,7 +33,6 @@
   textarea,
   input,
   select {
-    max-width: 100%;
     min-width: 0;
   }
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -41,6 +41,5 @@ thead th {
 
 table {
   display: block;
-  max-width: 100%;
   overflow-x: auto;
 }


### PR DESCRIPTION
I believe we need `max-width:100%` for everything. I don't see why any element would not have that.