### PR TITLE
refactor: better checkYear task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,9 @@
  * SOFTWARE.
  */
 
+const fs = require('fs')
+const child_process = require('child_process')
+
 module.exports = function (grunt) {
   'use strict';
   grunt.util.linefeed = '\n';
@@ -67,17 +70,26 @@ module.exports = function (grunt) {
         allFiles: [
           'scss/*.scss'
         ]
-      },
-      shell: {
-        checkYear: {
-	  command: 'git ls-files LICENSE "*.scss" "*.html" "*.js" | xargs -L1 grep -q 2015-' + new Date().getFullYear()
-        }
       }
     }
   );
   require('load-grunt-tasks') (grunt, { scope: 'devDependencies' });
-  grunt.registerTask('default', ['sasslint', 'sass:dist', 'shell']);
-  grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'shell']);
+
+  grunt.registerTask('checkYear', 'Checks the year patterns in copyright lines in source files.', () => {
+    const pattern = `2015-${new Date().getFullYear()}`
+    const invalidFiles = child_process.execSync('git ls-files LICENSE "*.scss" "*.html" "*.js"').toString().trim().split('\n').filter(file => {
+      return !fs.readFileSync(file).toString().includes(pattern)
+    })
+
+    invalidFiles.forEach(file => {
+      grunt.log.error(`The file, ${file}, does not include the pattern: ${pattern}`)
+    })
+
+    return invalidFiles.length === 0
+  })
+
+  grunt.registerTask('default', ['sasslint', 'sass:dist', 'checkYear']);
+  grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'checkYear']);
   grunt.registerTask('dev', ['sasslint', 'sass:dev', 'watch']);
 }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-sass": "^2.0.0",
     "grunt-sass-lint": "^0.2.4",
-    "grunt-shell": "1.1.2",
     "load-grunt-tasks": "3.4.0"
   }
 }


### PR DESCRIPTION
xargs usage does not seem cross-platform. ([See the comment](https://github.com/yegor256/tacit/issues/103#issuecomment-354238009)) So I rewrote `checkYear` task in javascript.

This also outputs better error messages when the required patterns are not found like:

```
Running "checkYear" task
>> The file, Gruntfile.js, does not include the pattern: 2015-2017
```

By this, we know which files have outdated copyright lines.