### PR TITLE
#inline-block: nav alignment

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -94,9 +94,10 @@ nav {
     text-align: center;
 
     li {
-      display: inline;
+      display: inline-block;
       margin-left: .5 * $em;
       margin-right: .5 * $em;
+      vertical-align: middle;
 
       &:first-child {
         margin-left: 0;


### PR DESCRIPTION
The responsive layout is broken, if we don't have these.