### PR TITLE
margins for footer and header

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "grunt-sass": "^2.0.0",
     "grunt-sass-lint": "^0.2.4",
     "load-grunt-tasks": "3.4.0"
+  },
+  "dependencies": {
+    "npm": "^6.1.0"
   }
 }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -69,11 +69,16 @@ section {
   width: 50 * $em;
 }
 
+article,
+header,
+footer {
+  padding: 2.4 * $em;
+}
+
 article {
   background: $white;
   border: 1px solid lighten($black, 85);
   border-radius: .4 * $em;
-  padding: 2.4 * $em;
 }
 
 header {

--- a/scss/_responsive.scss
+++ b/scss/_responsive.scss
@@ -26,7 +26,12 @@
   }
 
   article {
-    border-radius: 0;
+    border: 0;
+    padding: $em;
+  }
+
+  header,
+  footer {
     padding: $em;
   }
 


### PR DESCRIPTION
Better margins for footer and header. Also, removed the border from the article in mobile version -- it's redundant.