### PR TITLE
#176 Fixed warning during npm install: license should be a valid SPDX…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
     "css"
   ],
   "author": "Yegor Bugayenko",
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/yegor256/tacit"
-  },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/yegor256/tacit/issues"
   },


### PR DESCRIPTION
The old format is deprecated https://docs.npmjs.com/files/package.json