### PR TITLE
 #188 - make tables responsive

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -66,16 +66,18 @@ table {
       padding: .3 * $em .2 * $em;
 
       @media all and (max-width: 1024px) {
-        display: inline-block;
         border: 0;
+        display: inline-block;
       }
     }
 
-    th, td {
+    th,
+    td {
       font-size: 65%;
     }
 
-    span, code {
+    span,
+    code {
       font-size: 80%;
     }
 

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -29,7 +29,6 @@ th {
 td,
 th {
   border-bottom: (.06 * $em) solid $gray;
-  overflow: auto;
   padding: .825 * $em $em;
   text-align: left;
   vertical-align: top;
@@ -42,5 +41,51 @@ thead th {
 
 table {
   display: table;
-  overflow-x: auto;
+  width: 100%;
+
+  @media all and (max-width: 1024px) {
+    display: none;
+  }
+
+  thead {
+    @media all and (max-width: 1024px) {
+      display: none;
+    }
+  }
+
+  tr {
+    border-bottom-width: .12 * $em;
+
+    th {
+      border-bottom-width: .12 * $em;
+    }
+
+    td,
+    th {
+      overflow: hidden;
+      padding: .3 * $em .2 * $em;
+
+      @media all and (max-width: 1024px) {
+        display: inline-block;
+        border: 0;
+      }
+    }
+
+    th, td {
+      font-size: 65%;
+    }
+
+    span, code {
+      font-size: 80%;
+    }
+
+    @media all and (max-width: 1024px) {
+      display: inline-block;
+      margin: .6 * $em 0;
+    }
+  }
+
+  @media all and (max-width: 1024px) {
+    display: inline-block;
+  }
 }


### PR DESCRIPTION
+ reduce table overal font size
+ make tables responsive (after 1024px they turn into plain lists)

related issues: #182 and #89

Current final result (checked in Chrome, Firefox and Safari):

**Desktop view:**
<img width="1759" alt="screen shot 2019-02-28 at 22 31 18" src="https://user-images.githubusercontent.com/11976836/53600263-6a461380-3ba9-11e9-92a2-9ef28b34a986.png">

**"Mobile" view:**
<img width="472" alt="screen shot 2019-02-28 at 22 31 49" src="https://user-images.githubusercontent.com/11976836/53600269-6fa35e00-3ba9-11e9-951b-c2a04956efa8.png">


@yegor256 fyi