### PR TITLE
normal size for tables

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -71,16 +71,6 @@ table {
       }
     }
 
-    th,
-    td {
-      font-size: 65%;
-    }
-
-    span,
-    code {
-      font-size: 80%;
-    }
-
     @media all and (max-width: 1024px) {
       display: inline-block;
       margin: .6 * $em 0;


### PR DESCRIPTION
Let's reverse the changes made. Tables should be the same size as normal text.