### PR TITLE
Point main to CSS file for usage by bundlers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,8 @@ module.exports = function (grunt) {
             implementation: require('node-sass')
           },
           files: {
-            'dist/<%= pkg.name %>-<%= pkg.version %>.min.css': 'scss/main.scss'
+            'dist/<%= pkg.name %>-<%= pkg.version %>.min.css': 'scss/main.scss',
+            'dist/<%= pkg.name %>.min.css': 'scss/main.scss'
           }
         },
         uncompressed: {
@@ -59,7 +60,8 @@ module.exports = function (grunt) {
             implementation: require('node-sass')
           },
           files: {
-            'dist/<%= pkg.name %>-<%= pkg.version %>.css': 'scss/main.scss'
+            'dist/<%= pkg.name %>-<%= pkg.version %>.css': 'scss/main.scss',
+            'dist/<%= pkg.name %>.css': 'scss/main.scss'
           }
         }
       },
@@ -77,13 +79,17 @@ module.exports = function (grunt) {
       css_purge: {
         dist: {
           options: {},
-          src: 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
-          dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
+          files: {
+            'dist/<%= pkg.name %>-<%= pkg.version %>.min.css': 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
+            'dist/<%= pkg.name %>.min.css': 'dist/<%= pkg.name %>.min.css'
+          }
         },
         uncompressed: {
           options: {},
-          src: 'dist/<%= pkg.name %>-<%= pkg.version %>.css',
-          dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.css',
+          files: {
+            'dist/<%= pkg.name %>-<%= pkg.version %>.css': 'dist/<%= pkg.name %>-<%= pkg.version %>.css',
+            'dist/<%= pkg.name %>.css': 'dist/<%= pkg.name %>.css'
+          }
         },
       },
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
 
     })
   })
-  grunt.registerTask('default', ['sasslint', 'sass:dist', 'css_purge', 'checkYear', 'validate']);
+  grunt.registerTask('default', ['sasslint', 'sass:dist', 'sass:uncompressed', 'css_purge', 'checkYear', 'validate']);
   grunt.registerTask('rultor', ['sasslint', 'sass:dist', 'sass:uncompressed', 'css_purge', 'checkYear', 'validate']);
   grunt.registerTask('dev', ['sasslint', 'sass:dev', 'css_purge', 'watch']);
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Yegor Bugayenko
+ * Copyright (c) 2015-2024 Yegor Bugayenko
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 Yegor Bugayenko
+Copyright (c) 2015-2024 Yegor Bugayenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!--
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2023 Yegor Bugayenko
+ * Copyright (c) 2015-2024 Yegor Bugayenko
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -226,7 +226,7 @@
         <nav>
           <ul>
             <li>
-              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2023</small>
+              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2024</small>
             </li>
           </ul>
         </nav>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "copyright": "2015",
   "description": "CSS Framework for Dummies",
-  "main": "index.js",
+  "main": "dist/tacit-css.css",
   "scripts": {
     "test": "grunt --no-color",
     "rultor": "grunt rultor --no-color",

--- a/scss/_defs.scss
+++ b/scss/_defs.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_headings.scss
+++ b/scss/_headings.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_pre.scss
+++ b/scss/_pre.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_responsive.scss
+++ b/scss/_responsive.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2015-2023 Yegor Bugayenko
+// Copyright (c) 2015-2024 Yegor Bugayenko
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This allows to just do
```typescript
import 'tacit-css'
```
instead of
```typescript
import 'tacit-css/dist/tacit-css-1.6.0.css'
```
in your JS code when using a bundler like Webpack.