### PR TITLE
implement respecting hidden attribute

### DIFF
--- a/scss/_common.scss
+++ b/scss/_common.scss
@@ -1,0 +1,25 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2024 Yegor Bugayenko
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+*[hidden] {
+    display: none;
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 @import 'defs';
+@import 'common';
 @import 'tables';
 @import 'forms';
 @import 'pre';


### PR DESCRIPTION
This PR adds a **_defs.scss** include file to handle general style rules that are not strictly related to the grid.
For now, this file handles hiding of any element with the `hidden` attribute via `display: none`.