### PR TITLE
fix(build): replace node-sass with sass and disable css-purge shorten

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,9 @@ module.exports = (grunt) => {
             'dist/<%= pkg.name %>-<%= pkg.version %>.min.css': 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
             'dist/<%= pkg.name %>.min.css': 'dist/<%= pkg.name %>.min.css'
           },
-          options: {}
+          options: {
+            shorten: false
+          }
         },
         uncompressed: {
           files: {
@@ -38,7 +40,7 @@ module.exports = (grunt) => {
             'tacit.min.css': 'scss/main.scss'
           },
           options: {
-            implementation: require('node-sass'),
+            implementation: require('sass'),
             outputStyle: 'compressed',
             sourceMap: true
           }
@@ -49,7 +51,7 @@ module.exports = (grunt) => {
             'dist/<%= pkg.name %>.min.css': 'scss/main.scss'
           },
           options: {
-            implementation: require('node-sass'),
+            implementation: require('sass'),
             outputStyle: 'compressed',
             sourceMap: true
           }
@@ -60,7 +62,7 @@ module.exports = (grunt) => {
             'dist/<%= pkg.name %>.css': 'scss/main.scss'
           },
           options: {
-            implementation: require('node-sass'),
+            implementation: require('sass'),
             outputStyle: 'expanded',
             sourceMap: false
           }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grunt-sass": "4.0.0",
     "grunt-sass-lint": "0.2.4",
     "load-grunt-tasks": "5.1.0",
-    "node-sass": "9.0.0",
+    "sass": "^1.89.0",
     "npm": "11.4.1",
     "path": "0.12.7"
   },

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -49,10 +49,6 @@ table {
   tr {
     border-bottom-width: .12 * $em;
 
-    th {
-      border-bottom-width: .12 * $em;
-    }
-
     td,
     th {
       overflow: hidden;


### PR DESCRIPTION
Hi @yegor256,

### Notes

I couldn’t install dependencies properly due to issues with node-sass (which requires Visual Studio build tools). Although I installed Visual Studio, the problem persisted. To fix this, I replaced node-sass with sass (Dart Sass) which has better compatibility and easier installation.

If you prefer not to replace node-sass with sass, you can simply merge the part of this pull request that adds:
```js
options: {
  shorten: false
}
```
to the css_purge task in the Gruntfile.

### Description

- Replaced `node-sass` with `sass` to fix build issues related to Visual Studio dependencies.
- Added `shorten: false` option to `css-purge` to prevent incorrect shortening of border widths.

If you have any questions or need me to adjust anything, please feel free to let me know. I’m happy to help!