### PR TITLE
#219: Adds version to final css build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ const {glob} = require('glob'),
 module.exports = (grunt) => {
   grunt.util.linefeed = '\n';
   grunt.loadNpmTasks('grunt-css-purge');
+  grunt.loadNpmTasks('grunt-file-append');
   grunt.initConfig(
     {
       css_purge: {
@@ -32,6 +33,32 @@ module.exports = (grunt) => {
           },
           options: {}
         },
+      },
+      file_append: {
+        default_options: {
+          files: [
+            {
+              input: 'dist/<%= pkg.name %>.css',
+              output: 'dist/<%= pkg.name %>.css',
+              prepend: "/* <%= pkg.name %> <%= pkg.version %> */",
+            },
+            {
+              input: 'dist/<%= pkg.name %>.min.css',
+              output: 'dist/<%= pkg.name %>.min.css',
+              prepend: "/* <%= pkg.name %> <%= pkg.version %> */",
+            },
+            {
+              input: 'dist/<%= pkg.name %>-<%= pkg.version %>.css',
+              output: 'dist/<%= pkg.name %>-<%= pkg.version %>.css',
+              prepend: "/* <%= pkg.name %> <%= pkg.version %> */",
+            },
+            {
+              input: 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
+              output: 'dist/<%= pkg.name %>-<%= pkg.version %>.min.css',
+              prepend: "/* <%= pkg.name %> <%= pkg.version %> */",
+            }
+          ]
+        }
       },
       pkg: grunt.file.readJSON('package.json'),
       sass: {
@@ -112,6 +139,6 @@ module.exports = (grunt) => {
     });
   });
 
-  grunt.registerTask('default', ['sasslint', 'sass:dist', 'sass:uncompressed', 'css_purge', 'checkYear', 'validate']);
+  grunt.registerTask('default', ['sasslint', 'sass:dist', 'sass:uncompressed', 'css_purge', 'file_append', 'checkYear', 'validate']);
   grunt.registerTask('dev', ['sasslint', 'sass:dev', 'css_purge', 'watch']);
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt": "^1.4.3",
     "grunt-contrib-watch": "1.1.0",
     "grunt-css-purge": "1.1.0",
+    "grunt-file-append": "^0.0.7",
     "grunt-sass": "4.0.0",
     "grunt-sass-lint": "0.2.4",
     "load-grunt-tasks": "5.1.0",


### PR DESCRIPTION
Resolves: https://github.com/yegor256/tacit/issues/219

Adds a version to all files in the final CSS build.
Also introduces [grunt-file-append](https://www.npmjs.com/package/grunt-file-append) as a dev dependency.

Will look like this: 
`/* tacit-css 0.0.0 */body,input,textarea,select,button...`