### PR TITLE
Add padding to footer in _grid.scss

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -134,6 +134,7 @@ blockquote {
     color: $gray;
     font-size: .75 * $em;
     margin: 0;
+    padding: (.25 * $em) $em (.25 * $em) (.88 * $em);
   }
 
   p {


### PR DESCRIPTION
### Problem

The global CSS selector `footer` applies excessive spacing, which negatively affects the quote displayed in the footer.

**Before:**

<img width="1622" height="308" alt="Footer quote with excessive spacing" src="https://github.com/user-attachments/assets/1614c5c8-eb26-496c-a283-b37d0cea8a34" />

### Solution

After adding explicit `padding` for the footer quote, the author attribution is displayed more cleanly and consistently.

**After:**

<img width="1622" height="154" alt="Footer quote after padding fix" src="https://github.com/user-attachments/assets/c234be03-a2e1-490b-8fcb-1c034d6c74d3" />
