### PR TITLE
#207: preserve custom element borders

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -5,7 +5,6 @@
 @use 'functions' as *;
 
 * {
-  border: 0;
   border-collapse: separate;
   border-spacing: 0;
   box-sizing: border-box;
@@ -13,6 +12,14 @@
   max-width: 100%;
   padding: 0;
   vertical-align: baseline;
+}
+
+button,
+fieldset,
+input,
+select,
+textarea {
+  border: 0;
 }
 
 html,


### PR DESCRIPTION
Fixes #207.

This keeps Tacit's global reset from clearing borders on arbitrary custom-element hosts. The border reset remains explicit for form controls and fieldsets, where Tacit already sets or depends on that base style.

Validation:
- `npm test` -> Grunt completed sasslint, Sass builds, CSS purge, file append, year check, and CSS validation with `Done.`
- Playwright computed-style check with a Shadow DOM custom element using `:host { border: 7px solid rgb(1, 2, 3); }`: simulated old CSS returned `0px none rgb(25, 25, 25)`; patched CSS returned `7px solid rgb(1, 2, 3)`.
- `git diff --check` passed.
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.
