### PR TITLE
#220: style details/summary element

### DIFF
--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -62,3 +62,16 @@ sup {
 sub {
   bottom: -.25 * $em;
 }
+
+details {
+  summary {
+    background: $yellow;
+    cursor: pointer;
+    font-weight: 600;
+    padding: (.25 * $em) (.5 * $em);
+  }
+
+  &[open] summary {
+    margin-bottom: .5 * $em;
+  }
+}


### PR DESCRIPTION
The native `<details>` element renders without any framework styling, even though the `index.html` demo already includes a `<details>`/`<summary>` block. Without a rule in `_typography.scss`, summary is indistinguishable from surrounding prose and gives no hint that it is interactive.

The change adds a single rule in `scss/_typography.scss` that paints `summary` with the yellow accent already used elsewhere for `mark`, gives it a pointer cursor and a small padding, and adds a margin below the summary when `details[open]` is in the open state. No other selectors are touched and no new variables are introduced; the rule reuses `$yellow` and `$em` from `defs`.

Verified locally on Node 22 / npm 10 with `npm install` and `npx grunt --no-color`: the full build pipeline ran clean through `sasslint`, the two `sass` tasks, both `css_purge` passes, `file_append`, `checkYear`, and the W3C `validate` task. Grepping the produced `dist/tacit-css.css` confirms the new rules land in the output verbatim.

Closes #220
