### PR TITLE
#419 update footer copyright range to 2015-2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
         <nav>
           <ul>
             <li>
-              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2025</small>
+              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2026</small>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
The footer in `index.html:218` displayed `2015-2025` while every other source file in the repository — `LICENSE.txt`, `REUSE.toml`, `Gruntfile.js`, and every `scss/*.scss` — declared `2015-2026`. Issue #419 reported the drift.

The change updates the single occurrence of the stale year in the footer so the demo page matches the rest of the repository.

Ran `npm install` and `npx grunt` locally on the branch: the full default chain `sasslint -> sass:dist -> sass:uncompressed -> css_purge -> file_append -> checkYear -> validate` finishes with no failures.

Closes #419