### PR TITLE
#419 sync index.html footer year to 2015-2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
         <nav>
           <ul>
             <li>
-              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2025</small>
+              <small>Made by <a href="https://www.yegor256.com">@yegor256</a>, 2015-2026</small>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
The footer in `index.html:218` declared `2015-2025` while every SPDX header across the repository declared `2015-2026`. The `checkYear` Grunt task did not catch the drift because the same file already carried the matching pattern in its SPDX preamble on line 3, so the file as a whole already contained the canonical `2015-${new Date().getFullYear()}` string.

The visible footer rendered on the demo page now reads `Made by @yegor256, 2015-2026`, matching the SPDX headers in `Gruntfile.js`, `eslint.config.js`, every `scss/*.scss`, every `.github/workflows/*.yml`, `.rultor.yml`, `.0pdd.yml`, and the SPDX preamble on `index.html` line 3.

Ran `npm install` and `npx grunt --no-color` locally on `node v22.22.2`: sasslint, sass:dist, sass:uncompressed, css_purge, file_append, checkYear, and validate all reported `Done.` with no errors.

Fixes #419