### PR TITLE
#415 give tr a border-style so the bottom border paints

### DIFF
--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -39,7 +39,7 @@ table {
   }
 
   tr {
-    border-bottom-width: .12 * $em;
+    border-bottom: .12 * $em solid $gray;
 
     td,
     th {


### PR DESCRIPTION
Closes #415

`scss/_tables.scss:42` declared `border-bottom-width: .12 * $em;` on the `tr` rule without a `border-bottom-style`. The CSS initial value of `border-style` is `none`, so a width-only declaration paints nothing, and the intended row separator never appears in the rendered table.

The fix replaces the width-only declaration with the same shorthand the file already uses on `thead th` two rules above: `border-bottom: .12 * $em solid $gray;`. The compiled CSS now emits `table tr { border-bottom: 0.135rem solid #595959; }` in `dist/tacit-css.css` instead of a bare width.

Ran `npm install` and `npm test` locally on Node 22. The full Grunt pipeline finished cleanly: `sasslint`, both `sass` builds, `css_purge`, `file_append`, `checkYear`, and `validate` all passed with no warnings.
