### PR TITLE
fix: #422 sync REUSE.toml override copyright to 2015-2026

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -34,5 +34,5 @@ path = [
     "renovate.json",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"
+SPDX-FileCopyrightText = "Copyright (c) 2015-2026 Yegor Bugayenko"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
The `[[annotations]]` block in `REUSE.toml` overrides `SPDX-FileCopyrightText` on `**.json`, `**.md`, `**.png`, `**.svg`, `**.txt`, and the other paths it lists with `Copyright (c) 2025 Yegor Bugayenko`, while the preamble on line 1 of the same file and every other artifact in the repository — `Gruntfile.js`, `eslint.config.js`, every `scss/*.scss`, every `.github/workflows/*.yml`, `.rultor.yml`, `.0pdd.yml` — declares `Copyright (c) 2015-2026 Yegor Bugayenko`. Closes #422.

Changes line 37 of `REUSE.toml` from `Copyright (c) 2025 Yegor Bugayenko` to `Copyright (c) 2015-2026 Yegor Bugayenko`, so REUSE-aware consumers and downstream redistributors see the same copyright range on JSON, Markdown, PNG, and SVG assets that source files in the same archive already declare.

No code paths run; the change is a one-line metadata fix to a REUSE override. Verified locally that the resulting `REUSE.toml` matches the preamble and the rest of the tree.

Closes #422