### PR TITLE
fix: #421 match LICENSE.txt in checkYear git ls-files glob

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,7 @@ module.exports = (grunt) => {
   require('load-grunt-tasks')(grunt, { scope: 'devDependencies' });
 
   grunt.registerTask('checkYear', 'Checks the year patterns in copyright lines in source files.', () => {
-    const invalidFiles = cp.execSync('git ls-files LICENSE "*.scss" "*.html" "*.js"').toString().trim().split('\n').filter(
+    const invalidFiles = cp.execSync('git ls-files LICENSE.txt "*.scss" "*.html" "*.js"').toString().trim().split('\n').filter(
       file => !fs.readFileSync(file).toString().includes(pattern)
     );
     invalidFiles.forEach(file => {


### PR DESCRIPTION
The checkYear task at Gruntfile.js:115 passed the literal string LICENSE to git ls-files, which matches no path because the license at the repo root is LICENSE.txt. Issue #421 names the drift: LICENSE.txt is silently excluded from the year-check on every run, while the default Grunt chain still reports success.

This patch widens the literal to LICENSE.txt at the same line. After the change, git ls-files LICENSE.txt "*.scss" "*.html" "*.js" returns LICENSE.txt alongside the existing source files, so a stale Copyright (c) 2015-YYYY line in LICENSE.txt would now fail the checkYear task instead of passing unnoticed.

Ran npm install and npx grunt locally on Node 22. The default chain — sasslint, sass:dist, sass:uncompressed, css_purge:dist, css_purge:uncompressed, file_append:default_options, checkYear, validate — finished cleanly with no warnings; checkYear now enumerates LICENSE.txt as expected.

Closes #421