### PR TITLE
ci(#425): bump grunt workflow matrix to node 22

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-24.04, macos-15]
         java: [17]
-        node: [16]
+        node: [22]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The grunt workflow at .github/workflows/grunt.yml pinned the matrix to `node: [16]`, but the project's devDependencies no longer support that version: `eslint ^10.0.0` and `@eslint/js ^10.0.0` declare `engines.node: "^20.19.0 || ^22.13.0 || >=24"`, and `glob 13.0.6` declares `engines.node: "18 || 20 || >=22"`. Node 16 itself reached end of life on 2023-09-11.

The matrix now reads `node: [22]`, which sits inside every engines range above and is the current active LTS line. The os list and the java version are unchanged, so the windows-2022, ubuntu-24.04, and macos-15 jobs still run.

Built locally on node v22.22.2 against the same workflow steps: `npm install` completed without engine warnings, `npx grunt --no-color` ran sasslint, sass:dist, sass:uncompressed, css_purge, file_append, checkYear, and validate to completion, and `npx eslint .` exited clean.

Closes #425