### PR TITLE
fix: #426 drop unmaintained userland path package from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "grunt-sass-lint": "0.2.4",
     "load-grunt-tasks": "5.1.0",
     "npm": "11.16.0",
-    "path": "0.12.7",
     "sass": "^1.89.0"
   },
   "files": [


### PR DESCRIPTION
The `path` entry in `package.json` `devDependencies` shipped an unmaintained 2015 polyfill of Node's built-in `path` module. Nothing in this repository imports it; `Gruntfile.js:8` only does `require('path')`, which Node always resolves to the built-in core module ahead of `node_modules`. The userland package was dead weight pulled into `node_modules` and added supply-chain surface for no gain, as #426 describes.

Removing the entry takes the userland `path@0.12.7` out of the install closure. `Gruntfile.js` now binds `path` to the Node built-in unambiguously, so `path.basename`, `path.join`, and the rest follow current Node semantics rather than a 2015 polyfill that has since drifted from the spec. No source file under `scss/`, `index.html`, or the workflows is affected.

Locally on Node 22.22.2 I ran `npm install --force -g grunt-cli`, `npm install` (no `path@*` resolved), and the full default `grunt` pipeline (`sasslint`, `sass:dist`, `sass:uncompressed`, `css_purge`, `file_append`, `checkYear`, `validate`); the build was green end to end. Pre-existing `sasslint` warnings about merging `details` rules in `scss/_typography.scss` are unrelated to this change and tracked in #438.

Fixes #426
