### PR TITLE
Remove duplicate details rules

### DIFF
--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -64,19 +64,6 @@ sub {
 }
 
 details {
-  summary {
-    background: $yellow;
-    cursor: pointer;
-    font-weight: 600;
-    padding: (.25 * $em) (.5 * $em);
-  }
-
-  &[open] summary {
-    margin-bottom: .5 * $em;
-  }
-}
-
-details {
   &[open] {
     padding-bottom: .5 * $em;
 


### PR DESCRIPTION
Fixes #438.

`scss/_typography.scss` contained two consecutive `details` rules. The later rule superseded the first summary styles while also adding the open-state padding and nested element handling. This removes the stale first block so the source has one authoritative rule without changing the effective rendered declarations.

Checked locally:
- `grunt --no-color` passed
- Sass lint no longer reports mergeable `details` selectors
- the generated CSS contains the single expected `details` rule sequence